### PR TITLE
Add article registration page

### DIFF
--- a/groups.html
+++ b/groups.html
@@ -1,0 +1,354 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>רישום למאמרים</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background: linear-gradient(135deg, #6C63FF, #8E2DE2, #FF6EC4);
+            color: white;
+            margin: 0;
+            padding: 20px;
+        }
+        header {
+            text-align: center;
+            padding: 20px;
+            background: rgba(255,255,255,0.2);
+            border-radius: 15px;
+            margin-bottom: 20px;
+        }
+        nav a {
+            margin: 10px;
+            text-decoration: none;
+            color: #ffffff;
+            font-weight: bold;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        th, td {
+            border: 1px solid rgba(255,255,255,0.3);
+            padding: 8px;
+            text-align: center;
+        }
+        input[type="text"], select {
+            width: 100%;
+            padding: 4px;
+            margin: 2px 0;
+            box-sizing: border-box;
+        }
+    </style>
+</head>
+<body>
+<header>
+    <h1>רישום למאמרים</h1>
+    <nav>
+        <a href="index.html">דף הבית</a>
+    </nav>
+</header>
+<section>
+    <h2>טופס רישום לקבוצות</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>מספר קבוצה</th>
+                <th>חברי קבוצה (עד 5)</th>
+                <th>מאמר</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>1</td>
+                <td>
+                    <input type="text" placeholder="חבר 1">
+                    <input type="text" placeholder="חבר 2">
+                    <input type="text" placeholder="חבר 3">
+                    <input type="text" placeholder="חבר 4">
+                    <input type="text" placeholder="חבר 5">
+                </td>
+                <td>
+                    <select class="article-select">
+                        <option value="">בחר מאמר...</option>
+                        <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
+                        <option>Heller et al. (2023). Hack your organizational innovation</option>
+                        <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
+                        <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
+                        <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
+                        <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
+                        <option>Michael E. Porter (2008). Forces That Shape Competition</option>
+                        <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
+                        <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <td>2</td>
+                <td>
+                    <input type="text" placeholder="חבר 1">
+                    <input type="text" placeholder="חבר 2">
+                    <input type="text" placeholder="חבר 3">
+                    <input type="text" placeholder="חבר 4">
+                    <input type="text" placeholder="חבר 5">
+                </td>
+                <td>
+                    <select class="article-select">
+                        <option value="">בחר מאמר...</option>
+                        <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
+                        <option>Heller et al. (2023). Hack your organizational innovation</option>
+                        <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
+                        <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
+                        <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
+                        <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
+                        <option>Michael E. Porter (2008). Forces That Shape Competition</option>
+                        <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
+                        <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <td>3</td>
+                <td>
+                    <input type="text" placeholder="חבר 1">
+                    <input type="text" placeholder="חבר 2">
+                    <input type="text" placeholder="חבר 3">
+                    <input type="text" placeholder="חבר 4">
+                    <input type="text" placeholder="חבר 5">
+                </td>
+                <td>
+                    <select class="article-select">
+                        <option value="">בחר מאמר...</option>
+                        <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
+                        <option>Heller et al. (2023). Hack your organizational innovation</option>
+                        <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
+                        <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
+                        <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
+                        <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
+                        <option>Michael E. Porter (2008). Forces That Shape Competition</option>
+                        <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
+                        <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <td>4</td>
+                <td>
+                    <input type="text" placeholder="חבר 1">
+                    <input type="text" placeholder="חבר 2">
+                    <input type="text" placeholder="חבר 3">
+                    <input type="text" placeholder="חבר 4">
+                    <input type="text" placeholder="חבר 5">
+                </td>
+                <td>
+                    <select class="article-select">
+                        <option value="">בחר מאמר...</option>
+                        <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
+                        <option>Heller et al. (2023). Hack your organizational innovation</option>
+                        <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
+                        <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
+                        <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
+                        <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
+                        <option>Michael E. Porter (2008). Forces That Shape Competition</option>
+                        <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
+                        <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <td>5</td>
+                <td>
+                    <input type="text" placeholder="חבר 1">
+                    <input type="text" placeholder="חבר 2">
+                    <input type="text" placeholder="חבר 3">
+                    <input type="text" placeholder="חבר 4">
+                    <input type="text" placeholder="חבר 5">
+                </td>
+                <td>
+                    <select class="article-select">
+                        <option value="">בחר מאמר...</option>
+                        <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
+                        <option>Heller et al. (2023). Hack your organizational innovation</option>
+                        <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
+                        <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
+                        <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
+                        <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
+                        <option>Michael E. Porter (2008). Forces That Shape Competition</option>
+                        <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
+                        <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <td>6</td>
+                <td>
+                    <input type="text" placeholder="חבר 1">
+                    <input type="text" placeholder="חבר 2">
+                    <input type="text" placeholder="חבר 3">
+                    <input type="text" placeholder="חבר 4">
+                    <input type="text" placeholder="חבר 5">
+                </td>
+                <td>
+                    <select class="article-select">
+                        <option value="">בחר מאמר...</option>
+                        <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
+                        <option>Heller et al. (2023). Hack your organizational innovation</option>
+                        <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
+                        <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
+                        <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
+                        <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
+                        <option>Michael E. Porter (2008). Forces That Shape Competition</option>
+                        <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
+                        <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <td>7</td>
+                <td>
+                    <input type="text" placeholder="חבר 1">
+                    <input type="text" placeholder="חבר 2">
+                    <input type="text" placeholder="חבר 3">
+                    <input type="text" placeholder="חבר 4">
+                    <input type="text" placeholder="חבר 5">
+                </td>
+                <td>
+                    <select class="article-select">
+                        <option value="">בחר מאמר...</option>
+                        <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
+                        <option>Heller et al. (2023). Hack your organizational innovation</option>
+                        <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
+                        <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
+                        <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
+                        <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
+                        <option>Michael E. Porter (2008). Forces That Shape Competition</option>
+                        <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
+                        <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <td>8</td>
+                <td>
+                    <input type="text" placeholder="חבר 1">
+                    <input type="text" placeholder="חבר 2">
+                    <input type="text" placeholder="חבר 3">
+                    <input type="text" placeholder="חבר 4">
+                    <input type="text" placeholder="חבר 5">
+                </td>
+                <td>
+                    <select class="article-select">
+                        <option value="">בחר מאמר...</option>
+                        <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
+                        <option>Heller et al. (2023). Hack your organizational innovation</option>
+                        <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
+                        <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
+                        <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
+                        <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
+                        <option>Michael E. Porter (2008). Forces That Shape Competition</option>
+                        <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
+                        <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <td>9</td>
+                <td>
+                    <input type="text" placeholder="חבר 1">
+                    <input type="text" placeholder="חבר 2">
+                    <input type="text" placeholder="חבר 3">
+                    <input type="text" placeholder="חבר 4">
+                    <input type="text" placeholder="חבר 5">
+                </td>
+                <td>
+                    <select class="article-select">
+                        <option value="">בחר מאמר...</option>
+                        <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
+                        <option>Heller et al. (2023). Hack your organizational innovation</option>
+                        <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
+                        <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
+                        <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
+                        <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
+                        <option>Michael E. Porter (2008). Forces That Shape Competition</option>
+                        <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
+                        <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <td>10</td>
+                <td>
+                    <input type="text" placeholder="חבר 1">
+                    <input type="text" placeholder="חבר 2">
+                    <input type="text" placeholder="חבר 3">
+                    <input type="text" placeholder="חבר 4">
+                    <input type="text" placeholder="חבר 5">
+                </td>
+                <td>
+                    <select class="article-select">
+                        <option value="">בחר מאמר...</option>
+                        <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
+                        <option>Heller et al. (2023). Hack your organizational innovation</option>
+                        <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
+                        <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
+                        <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
+                        <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
+                        <option>Michael E. Porter (2008). Forces That Shape Competition</option>
+                        <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
+                        <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                    </select>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</section>
+<script>
+const selects = document.querySelectorAll('.article-select');
+function updateAvailability() {
+    const chosen = Array.from(selects).map(s => s.value).filter(v => v);
+    selects.forEach(select => {
+        const current = select.value;
+        Array.from(select.options).forEach(opt => {
+            if (opt.value === '') return;
+            if (chosen.includes(opt.value) && opt.value !== current) {
+                opt.disabled = true;
+            } else {
+                opt.disabled = false;
+            }
+        });
+    });
+    saveData();
+}
+function saveData() {
+    const rows = document.querySelectorAll('tbody tr');
+    const data = [];
+    rows.forEach(row => {
+        const members = Array.from(row.querySelectorAll('input')).map(i => i.value);
+        const article = row.querySelector('select').value;
+        data.push({members, article});
+    });
+    localStorage.setItem('groupsData', JSON.stringify(data));
+}
+function loadData() {
+    const data = JSON.parse(localStorage.getItem('groupsData'));
+    if (!data) return;
+    const rows = document.querySelectorAll('tbody tr');
+    rows.forEach((row, idx) => {
+        const d = data[idx];
+        if (!d) return;
+        Array.from(row.querySelectorAll('input')).forEach((input, i) => {
+            input.value = d.members[i] || '';
+        });
+        row.querySelector('select').value = d.article || '';
+    });
+}
+document.addEventListener('DOMContentLoaded', () => {
+    loadData();
+    updateAvailability();
+    selects.forEach(sel => sel.addEventListener('change', updateAvailability));
+    document.querySelectorAll('input').forEach(input => input.addEventListener('input', saveData));
+});
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
         <a href="#goals">מטרות הקורס</a> | 
         <a href="#grading">מרכיבי הציון</a> | 
         <a href="#schedule">רשימת נושאים</a> | 
-        <a href="#articles">רשימת קריאה</a>
+        <a href="#articles">רשימת קריאה</a> | <a href="groups.html">רישום למאמרים</a>
     </nav>
 </header>
 


### PR DESCRIPTION
## Summary
- link to new registration page in navigation
- create `groups.html` with a table for 10 groups
- implement JavaScript to prevent duplicate article selections and store data locally

## Testing
- `html5validator --root . --skip-non-html --also-check-css --log-level ERROR` *(fails: command not found)*
- `tidy -q groups.html > /dev/null` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533248e0d083279034602eb3864712