### PR TITLE
Add optional articles to group selection

### DIFF
--- a/groups.html
+++ b/groups.html
@@ -72,16 +72,38 @@
                 <td>
                     <select class="article-select">
                         <option value="">בחר מאמר...</option>
-                        <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
-                        <option>Heller et al. (2023). Hack your organizational innovation</option>
-                        <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
-                        <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
-                        <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
-                        <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
-                        <option>Michael E. Porter (2008). Forces That Shape Competition</option>
-                        <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
-                        <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                        <optgroup label="מאמרי חובה">
+                            <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
+                            <option>Heller et al. (2023). Hack your organizational innovation</option>
+                            <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
+                            <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
+                            <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
+                            <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
+                            <option>Michael E. Porter (2008). Forces That Shape Competition</option>
+                            <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
+                            <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                        </optgroup>
+                        <optgroup label="מאמרי רשות">
+                            <option>Atkinson & Barker (2023). AI and the social construction of creativity</option>
+                            <option>Bender-Salazar (2023). Design thinking</option>
+                            <option>Blank (2019). Why companies do ‘Innovation Theater’</option>
+                            <option>Christensen et al. (2015). What Is Disruptive Innovation?</option>
+                            <option>Christensen et al. (2018). Disruptive innovation: An intellectual history</option>
+                            <option>Christensen et al. (2017). Africa’s New Generation of Innovators</option>
+                            <option>CBINSIGHTS (2020). Post-Covid World</option>
+                            <option>Dweck (2016). Growth Mindset</option>
+                            <option>Halligan (2020). The Experience Disrupter</option>
+                            <option>Kirsner (2018). Obstacles to innovation in large companies</option>
+                            <option>Kolko (2015). Design Thinking Comes of Age</option>
+                            <option>Maaravi et al. (2022). Perceptions of victimhood and entrepreneurial tendencies</option>
+                            <option>Maaravi & Heller (2021). Digital Innovation in Times of Crisis</option>
+                            <option>Maaravi et al. (2020). Ideation in the digital age</option>
+                            <option>Maaravi (2018). Using hackathons to teach management consulting</option>
+                            <option>Satell (2017). 4 Types of Innovation</option>
+                            <option>Zhexembayeva (2020). Organizational Change</option>
+                        </optgroup>
                     </select>
+
                 </td>
             </tr>
             <tr>
@@ -96,16 +118,38 @@
                 <td>
                     <select class="article-select">
                         <option value="">בחר מאמר...</option>
-                        <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
-                        <option>Heller et al. (2023). Hack your organizational innovation</option>
-                        <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
-                        <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
-                        <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
-                        <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
-                        <option>Michael E. Porter (2008). Forces That Shape Competition</option>
-                        <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
-                        <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                        <optgroup label="מאמרי חובה">
+                            <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
+                            <option>Heller et al. (2023). Hack your organizational innovation</option>
+                            <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
+                            <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
+                            <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
+                            <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
+                            <option>Michael E. Porter (2008). Forces That Shape Competition</option>
+                            <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
+                            <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                        </optgroup>
+                        <optgroup label="מאמרי רשות">
+                            <option>Atkinson & Barker (2023). AI and the social construction of creativity</option>
+                            <option>Bender-Salazar (2023). Design thinking</option>
+                            <option>Blank (2019). Why companies do ‘Innovation Theater’</option>
+                            <option>Christensen et al. (2015). What Is Disruptive Innovation?</option>
+                            <option>Christensen et al. (2018). Disruptive innovation: An intellectual history</option>
+                            <option>Christensen et al. (2017). Africa’s New Generation of Innovators</option>
+                            <option>CBINSIGHTS (2020). Post-Covid World</option>
+                            <option>Dweck (2016). Growth Mindset</option>
+                            <option>Halligan (2020). The Experience Disrupter</option>
+                            <option>Kirsner (2018). Obstacles to innovation in large companies</option>
+                            <option>Kolko (2015). Design Thinking Comes of Age</option>
+                            <option>Maaravi et al. (2022). Perceptions of victimhood and entrepreneurial tendencies</option>
+                            <option>Maaravi & Heller (2021). Digital Innovation in Times of Crisis</option>
+                            <option>Maaravi et al. (2020). Ideation in the digital age</option>
+                            <option>Maaravi (2018). Using hackathons to teach management consulting</option>
+                            <option>Satell (2017). 4 Types of Innovation</option>
+                            <option>Zhexembayeva (2020). Organizational Change</option>
+                        </optgroup>
                     </select>
+
                 </td>
             </tr>
             <tr>
@@ -120,16 +164,38 @@
                 <td>
                     <select class="article-select">
                         <option value="">בחר מאמר...</option>
-                        <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
-                        <option>Heller et al. (2023). Hack your organizational innovation</option>
-                        <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
-                        <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
-                        <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
-                        <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
-                        <option>Michael E. Porter (2008). Forces That Shape Competition</option>
-                        <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
-                        <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                        <optgroup label="מאמרי חובה">
+                            <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
+                            <option>Heller et al. (2023). Hack your organizational innovation</option>
+                            <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
+                            <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
+                            <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
+                            <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
+                            <option>Michael E. Porter (2008). Forces That Shape Competition</option>
+                            <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
+                            <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                        </optgroup>
+                        <optgroup label="מאמרי רשות">
+                            <option>Atkinson & Barker (2023). AI and the social construction of creativity</option>
+                            <option>Bender-Salazar (2023). Design thinking</option>
+                            <option>Blank (2019). Why companies do ‘Innovation Theater’</option>
+                            <option>Christensen et al. (2015). What Is Disruptive Innovation?</option>
+                            <option>Christensen et al. (2018). Disruptive innovation: An intellectual history</option>
+                            <option>Christensen et al. (2017). Africa’s New Generation of Innovators</option>
+                            <option>CBINSIGHTS (2020). Post-Covid World</option>
+                            <option>Dweck (2016). Growth Mindset</option>
+                            <option>Halligan (2020). The Experience Disrupter</option>
+                            <option>Kirsner (2018). Obstacles to innovation in large companies</option>
+                            <option>Kolko (2015). Design Thinking Comes of Age</option>
+                            <option>Maaravi et al. (2022). Perceptions of victimhood and entrepreneurial tendencies</option>
+                            <option>Maaravi & Heller (2021). Digital Innovation in Times of Crisis</option>
+                            <option>Maaravi et al. (2020). Ideation in the digital age</option>
+                            <option>Maaravi (2018). Using hackathons to teach management consulting</option>
+                            <option>Satell (2017). 4 Types of Innovation</option>
+                            <option>Zhexembayeva (2020). Organizational Change</option>
+                        </optgroup>
                     </select>
+
                 </td>
             </tr>
             <tr>
@@ -144,16 +210,38 @@
                 <td>
                     <select class="article-select">
                         <option value="">בחר מאמר...</option>
-                        <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
-                        <option>Heller et al. (2023). Hack your organizational innovation</option>
-                        <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
-                        <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
-                        <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
-                        <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
-                        <option>Michael E. Porter (2008). Forces That Shape Competition</option>
-                        <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
-                        <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                        <optgroup label="מאמרי חובה">
+                            <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
+                            <option>Heller et al. (2023). Hack your organizational innovation</option>
+                            <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
+                            <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
+                            <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
+                            <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
+                            <option>Michael E. Porter (2008). Forces That Shape Competition</option>
+                            <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
+                            <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                        </optgroup>
+                        <optgroup label="מאמרי רשות">
+                            <option>Atkinson & Barker (2023). AI and the social construction of creativity</option>
+                            <option>Bender-Salazar (2023). Design thinking</option>
+                            <option>Blank (2019). Why companies do ‘Innovation Theater’</option>
+                            <option>Christensen et al. (2015). What Is Disruptive Innovation?</option>
+                            <option>Christensen et al. (2018). Disruptive innovation: An intellectual history</option>
+                            <option>Christensen et al. (2017). Africa’s New Generation of Innovators</option>
+                            <option>CBINSIGHTS (2020). Post-Covid World</option>
+                            <option>Dweck (2016). Growth Mindset</option>
+                            <option>Halligan (2020). The Experience Disrupter</option>
+                            <option>Kirsner (2018). Obstacles to innovation in large companies</option>
+                            <option>Kolko (2015). Design Thinking Comes of Age</option>
+                            <option>Maaravi et al. (2022). Perceptions of victimhood and entrepreneurial tendencies</option>
+                            <option>Maaravi & Heller (2021). Digital Innovation in Times of Crisis</option>
+                            <option>Maaravi et al. (2020). Ideation in the digital age</option>
+                            <option>Maaravi (2018). Using hackathons to teach management consulting</option>
+                            <option>Satell (2017). 4 Types of Innovation</option>
+                            <option>Zhexembayeva (2020). Organizational Change</option>
+                        </optgroup>
                     </select>
+
                 </td>
             </tr>
             <tr>
@@ -168,16 +256,38 @@
                 <td>
                     <select class="article-select">
                         <option value="">בחר מאמר...</option>
-                        <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
-                        <option>Heller et al. (2023). Hack your organizational innovation</option>
-                        <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
-                        <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
-                        <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
-                        <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
-                        <option>Michael E. Porter (2008). Forces That Shape Competition</option>
-                        <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
-                        <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                        <optgroup label="מאמרי חובה">
+                            <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
+                            <option>Heller et al. (2023). Hack your organizational innovation</option>
+                            <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
+                            <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
+                            <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
+                            <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
+                            <option>Michael E. Porter (2008). Forces That Shape Competition</option>
+                            <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
+                            <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                        </optgroup>
+                        <optgroup label="מאמרי רשות">
+                            <option>Atkinson & Barker (2023). AI and the social construction of creativity</option>
+                            <option>Bender-Salazar (2023). Design thinking</option>
+                            <option>Blank (2019). Why companies do ‘Innovation Theater’</option>
+                            <option>Christensen et al. (2015). What Is Disruptive Innovation?</option>
+                            <option>Christensen et al. (2018). Disruptive innovation: An intellectual history</option>
+                            <option>Christensen et al. (2017). Africa’s New Generation of Innovators</option>
+                            <option>CBINSIGHTS (2020). Post-Covid World</option>
+                            <option>Dweck (2016). Growth Mindset</option>
+                            <option>Halligan (2020). The Experience Disrupter</option>
+                            <option>Kirsner (2018). Obstacles to innovation in large companies</option>
+                            <option>Kolko (2015). Design Thinking Comes of Age</option>
+                            <option>Maaravi et al. (2022). Perceptions of victimhood and entrepreneurial tendencies</option>
+                            <option>Maaravi & Heller (2021). Digital Innovation in Times of Crisis</option>
+                            <option>Maaravi et al. (2020). Ideation in the digital age</option>
+                            <option>Maaravi (2018). Using hackathons to teach management consulting</option>
+                            <option>Satell (2017). 4 Types of Innovation</option>
+                            <option>Zhexembayeva (2020). Organizational Change</option>
+                        </optgroup>
                     </select>
+
                 </td>
             </tr>
             <tr>
@@ -192,16 +302,38 @@
                 <td>
                     <select class="article-select">
                         <option value="">בחר מאמר...</option>
-                        <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
-                        <option>Heller et al. (2023). Hack your organizational innovation</option>
-                        <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
-                        <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
-                        <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
-                        <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
-                        <option>Michael E. Porter (2008). Forces That Shape Competition</option>
-                        <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
-                        <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                        <optgroup label="מאמרי חובה">
+                            <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
+                            <option>Heller et al. (2023). Hack your organizational innovation</option>
+                            <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
+                            <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
+                            <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
+                            <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
+                            <option>Michael E. Porter (2008). Forces That Shape Competition</option>
+                            <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
+                            <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                        </optgroup>
+                        <optgroup label="מאמרי רשות">
+                            <option>Atkinson & Barker (2023). AI and the social construction of creativity</option>
+                            <option>Bender-Salazar (2023). Design thinking</option>
+                            <option>Blank (2019). Why companies do ‘Innovation Theater’</option>
+                            <option>Christensen et al. (2015). What Is Disruptive Innovation?</option>
+                            <option>Christensen et al. (2018). Disruptive innovation: An intellectual history</option>
+                            <option>Christensen et al. (2017). Africa’s New Generation of Innovators</option>
+                            <option>CBINSIGHTS (2020). Post-Covid World</option>
+                            <option>Dweck (2016). Growth Mindset</option>
+                            <option>Halligan (2020). The Experience Disrupter</option>
+                            <option>Kirsner (2018). Obstacles to innovation in large companies</option>
+                            <option>Kolko (2015). Design Thinking Comes of Age</option>
+                            <option>Maaravi et al. (2022). Perceptions of victimhood and entrepreneurial tendencies</option>
+                            <option>Maaravi & Heller (2021). Digital Innovation in Times of Crisis</option>
+                            <option>Maaravi et al. (2020). Ideation in the digital age</option>
+                            <option>Maaravi (2018). Using hackathons to teach management consulting</option>
+                            <option>Satell (2017). 4 Types of Innovation</option>
+                            <option>Zhexembayeva (2020). Organizational Change</option>
+                        </optgroup>
                     </select>
+
                 </td>
             </tr>
             <tr>
@@ -216,16 +348,38 @@
                 <td>
                     <select class="article-select">
                         <option value="">בחר מאמר...</option>
-                        <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
-                        <option>Heller et al. (2023). Hack your organizational innovation</option>
-                        <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
-                        <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
-                        <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
-                        <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
-                        <option>Michael E. Porter (2008). Forces That Shape Competition</option>
-                        <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
-                        <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                        <optgroup label="מאמרי חובה">
+                            <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
+                            <option>Heller et al. (2023). Hack your organizational innovation</option>
+                            <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
+                            <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
+                            <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
+                            <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
+                            <option>Michael E. Porter (2008). Forces That Shape Competition</option>
+                            <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
+                            <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                        </optgroup>
+                        <optgroup label="מאמרי רשות">
+                            <option>Atkinson & Barker (2023). AI and the social construction of creativity</option>
+                            <option>Bender-Salazar (2023). Design thinking</option>
+                            <option>Blank (2019). Why companies do ‘Innovation Theater’</option>
+                            <option>Christensen et al. (2015). What Is Disruptive Innovation?</option>
+                            <option>Christensen et al. (2018). Disruptive innovation: An intellectual history</option>
+                            <option>Christensen et al. (2017). Africa’s New Generation of Innovators</option>
+                            <option>CBINSIGHTS (2020). Post-Covid World</option>
+                            <option>Dweck (2016). Growth Mindset</option>
+                            <option>Halligan (2020). The Experience Disrupter</option>
+                            <option>Kirsner (2018). Obstacles to innovation in large companies</option>
+                            <option>Kolko (2015). Design Thinking Comes of Age</option>
+                            <option>Maaravi et al. (2022). Perceptions of victimhood and entrepreneurial tendencies</option>
+                            <option>Maaravi & Heller (2021). Digital Innovation in Times of Crisis</option>
+                            <option>Maaravi et al. (2020). Ideation in the digital age</option>
+                            <option>Maaravi (2018). Using hackathons to teach management consulting</option>
+                            <option>Satell (2017). 4 Types of Innovation</option>
+                            <option>Zhexembayeva (2020). Organizational Change</option>
+                        </optgroup>
                     </select>
+
                 </td>
             </tr>
             <tr>
@@ -240,16 +394,38 @@
                 <td>
                     <select class="article-select">
                         <option value="">בחר מאמר...</option>
-                        <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
-                        <option>Heller et al. (2023). Hack your organizational innovation</option>
-                        <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
-                        <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
-                        <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
-                        <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
-                        <option>Michael E. Porter (2008). Forces That Shape Competition</option>
-                        <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
-                        <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                        <optgroup label="מאמרי חובה">
+                            <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
+                            <option>Heller et al. (2023). Hack your organizational innovation</option>
+                            <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
+                            <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
+                            <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
+                            <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
+                            <option>Michael E. Porter (2008). Forces That Shape Competition</option>
+                            <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
+                            <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                        </optgroup>
+                        <optgroup label="מאמרי רשות">
+                            <option>Atkinson & Barker (2023). AI and the social construction of creativity</option>
+                            <option>Bender-Salazar (2023). Design thinking</option>
+                            <option>Blank (2019). Why companies do ‘Innovation Theater’</option>
+                            <option>Christensen et al. (2015). What Is Disruptive Innovation?</option>
+                            <option>Christensen et al. (2018). Disruptive innovation: An intellectual history</option>
+                            <option>Christensen et al. (2017). Africa’s New Generation of Innovators</option>
+                            <option>CBINSIGHTS (2020). Post-Covid World</option>
+                            <option>Dweck (2016). Growth Mindset</option>
+                            <option>Halligan (2020). The Experience Disrupter</option>
+                            <option>Kirsner (2018). Obstacles to innovation in large companies</option>
+                            <option>Kolko (2015). Design Thinking Comes of Age</option>
+                            <option>Maaravi et al. (2022). Perceptions of victimhood and entrepreneurial tendencies</option>
+                            <option>Maaravi & Heller (2021). Digital Innovation in Times of Crisis</option>
+                            <option>Maaravi et al. (2020). Ideation in the digital age</option>
+                            <option>Maaravi (2018). Using hackathons to teach management consulting</option>
+                            <option>Satell (2017). 4 Types of Innovation</option>
+                            <option>Zhexembayeva (2020). Organizational Change</option>
+                        </optgroup>
                     </select>
+
                 </td>
             </tr>
             <tr>
@@ -264,16 +440,38 @@
                 <td>
                     <select class="article-select">
                         <option value="">בחר מאמר...</option>
-                        <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
-                        <option>Heller et al. (2023). Hack your organizational innovation</option>
-                        <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
-                        <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
-                        <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
-                        <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
-                        <option>Michael E. Porter (2008). Forces That Shape Competition</option>
-                        <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
-                        <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                        <optgroup label="מאמרי חובה">
+                            <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
+                            <option>Heller et al. (2023). Hack your organizational innovation</option>
+                            <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
+                            <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
+                            <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
+                            <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
+                            <option>Michael E. Porter (2008). Forces That Shape Competition</option>
+                            <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
+                            <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                        </optgroup>
+                        <optgroup label="מאמרי רשות">
+                            <option>Atkinson & Barker (2023). AI and the social construction of creativity</option>
+                            <option>Bender-Salazar (2023). Design thinking</option>
+                            <option>Blank (2019). Why companies do ‘Innovation Theater’</option>
+                            <option>Christensen et al. (2015). What Is Disruptive Innovation?</option>
+                            <option>Christensen et al. (2018). Disruptive innovation: An intellectual history</option>
+                            <option>Christensen et al. (2017). Africa’s New Generation of Innovators</option>
+                            <option>CBINSIGHTS (2020). Post-Covid World</option>
+                            <option>Dweck (2016). Growth Mindset</option>
+                            <option>Halligan (2020). The Experience Disrupter</option>
+                            <option>Kirsner (2018). Obstacles to innovation in large companies</option>
+                            <option>Kolko (2015). Design Thinking Comes of Age</option>
+                            <option>Maaravi et al. (2022). Perceptions of victimhood and entrepreneurial tendencies</option>
+                            <option>Maaravi & Heller (2021). Digital Innovation in Times of Crisis</option>
+                            <option>Maaravi et al. (2020). Ideation in the digital age</option>
+                            <option>Maaravi (2018). Using hackathons to teach management consulting</option>
+                            <option>Satell (2017). 4 Types of Innovation</option>
+                            <option>Zhexembayeva (2020). Organizational Change</option>
+                        </optgroup>
                     </select>
+
                 </td>
             </tr>
             <tr>
@@ -288,16 +486,38 @@
                 <td>
                     <select class="article-select">
                         <option value="">בחר מאמר...</option>
-                        <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
-                        <option>Heller et al. (2023). Hack your organizational innovation</option>
-                        <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
-                        <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
-                        <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
-                        <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
-                        <option>Michael E. Porter (2008). Forces That Shape Competition</option>
-                        <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
-                        <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                        <optgroup label="מאמרי חובה">
+                            <option>Grilli & Pedota (2024). Creativity and artificial intelligence</option>
+                            <option>Heller et al. (2023). Hack your organizational innovation</option>
+                            <option>Boyd & Goldenberg (2013). Inside the Box Innovation</option>
+                            <option>Kariv et al. (2024). Process innovation is technology transfer too!</option>
+                            <option>Leonard & Rayport (1997). Spark Innovation Through Empathic Design</option>
+                            <option>Maaravi et al. (2023). Using Leading Questions to Reduce Resistance to Innovation.</option>
+                            <option>Michael E. Porter (2008). Forces That Shape Competition</option>
+                            <option>Oreg & Goldenberg (2005). Resistance to Innovation</option>
+                            <option>Vinchon et al. (2023). Artificial intelligence & creativity</option>
+                        </optgroup>
+                        <optgroup label="מאמרי רשות">
+                            <option>Atkinson & Barker (2023). AI and the social construction of creativity</option>
+                            <option>Bender-Salazar (2023). Design thinking</option>
+                            <option>Blank (2019). Why companies do ‘Innovation Theater’</option>
+                            <option>Christensen et al. (2015). What Is Disruptive Innovation?</option>
+                            <option>Christensen et al. (2018). Disruptive innovation: An intellectual history</option>
+                            <option>Christensen et al. (2017). Africa’s New Generation of Innovators</option>
+                            <option>CBINSIGHTS (2020). Post-Covid World</option>
+                            <option>Dweck (2016). Growth Mindset</option>
+                            <option>Halligan (2020). The Experience Disrupter</option>
+                            <option>Kirsner (2018). Obstacles to innovation in large companies</option>
+                            <option>Kolko (2015). Design Thinking Comes of Age</option>
+                            <option>Maaravi et al. (2022). Perceptions of victimhood and entrepreneurial tendencies</option>
+                            <option>Maaravi & Heller (2021). Digital Innovation in Times of Crisis</option>
+                            <option>Maaravi et al. (2020). Ideation in the digital age</option>
+                            <option>Maaravi (2018). Using hackathons to teach management consulting</option>
+                            <option>Satell (2017). 4 Types of Innovation</option>
+                            <option>Zhexembayeva (2020). Organizational Change</option>
+                        </optgroup>
                     </select>
+
                 </td>
             </tr>
         </tbody>


### PR DESCRIPTION
## Summary
- include optional reading in groups.html
- separate mandatory vs optional lists using optgroup labels

## Testing
- `grep -n "optgroup" -n groups.html`

------
https://chatgpt.com/codex/tasks/task_e_685334be57a4832780e8eb650a13bf9d